### PR TITLE
Twitter has changed their API:

### DIFF
--- a/tweet.go
+++ b/tweet.go
@@ -30,6 +30,7 @@ type Tweet struct {
 	Source               string                 `json:"source"`
 	Scopes               map[string]interface{} `json:"scopes"`
 	Text                 string                 `json:"text"`
+	FullText             string                 `json:"full_text"`
 	Truncated            bool                   `json:"truncated"`
 	User                 User                   `json:"user"`
 	WithheldCopyright    bool                   `json:"withheld_copyright"`


### PR DESCRIPTION
      https://dev.twitter.com/overview/api/upcoming-changes-to-tweets

In order to get tweets that are longer than 140 characters, you must add the parameter to any REST API Twitter call.
      tweet_mode=extended

When this param is added, the text will now come into new json tweet field, "full_text" instead of the regular "text" field.